### PR TITLE
Whitelisting channel social handles in chat

### DIFF
--- a/caibot/Channel/TwitchChannel.js
+++ b/caibot/Channel/TwitchChannel.js
@@ -14,11 +14,13 @@ class TwitchChannel{
     reactions;
     recentTimeouts = [];
     msgLog = {};
+    socials;
 
-    constructor(channel_key, channel_name, messages, mods, moderationSettings, hasCommands, hasReactions) {
+    constructor(channel_key, channel_name, messages, socials, mods, moderationSettings, hasCommands, hasReactions) {
         this.channel_key = channel_key;
         this.channel_name = channel_name;
         this.messages = messages;
+        this.socials = checkSocials(socials);
         this.mods = mods;
         this.moderationSettings = new Moderation.Moderation(moderationSettings);
         this.commands = new CommandsController.CommandsController(hasCommands);
@@ -120,6 +122,28 @@ class TwitchChannel{
 
     hasModeration() {
         return this.moderationSettings.isActive();
+    }
+
+    /**
+     * Function checks the json structure provided as param for duplicated social handles
+     * and provides all socials in an array in order to let the correct data be used during runtime of the bot.
+     * 
+     * @param {Array} socials 
+     * @returns JSON object containing the channels saved social handles on different platforms.
+     */
+    checkSocials(socials) {
+        const socialArray = [];
+        for (let objectKey in socials) { // for every index in socials (provided array)
+            let currentObj = socials[objectKey]; // saves the element (needs to be a json object) of this iteration
+            let keyName = Object.keys(currentObj); // gets the key(s) of the object and returns an array with the key(s)
+            if(keyName.length === 1) { // Only care if there is just one key in the object, if there is more than 1 something is very wrong. 
+                let objKey = Object.keys(currentObj)[0]; // Retrive the name of the key saved at position 0 in the array.
+                let objValue = Object.values(currentObj)[0]; // Retrive the name of the value saved at position 0 in the array.
+                let socialObj = { [objKey]:objValue }; // Recreate the object to ensure the format required. (Memory issue?) Luckily this isn't C...
+                socialArray.push(socialObj); // Add the newly created object to the array of socials.
+            }
+        }
+        return socialArray;
     }
 }
 module.exports.TwitchChannel = TwitchChannel;

--- a/caibot/Channel/TwitchChannel.js
+++ b/caibot/Channel/TwitchChannel.js
@@ -8,13 +8,13 @@ class TwitchChannel{
     channel_key;
     channel_name;
     messages;
+    socials;
     mods = [];
     moderationSettings;
     commands;
     reactions;
     recentTimeouts = [];
     msgLog = {};
-    socials;
 
     constructor(channel_key, channel_name, messages, socials, mods, moderationSettings, hasCommands, hasReactions) {
         this.channel_key = channel_key;

--- a/caibot/Channel/moderation/LinkFilter.js
+++ b/caibot/Channel/moderation/LinkFilter.js
@@ -1,19 +1,40 @@
 const {ModerationFilter} = require("./ModerationFilter");
-const discordLink = /(d *i *s *c *o *r *d *(\.|\,) *g *g\/.+)+/gmi;
+const discordLink = /(d *i *s *c *o *r *d *(\.|\,) *g *g\/(?<handle>.+))+/gmi;
 const nsfwLink = /((phub|pornhub|xnxx|xvideos|xHamster|YouPorn|HClips|Porn|TnaFlix|Tube8|spankbang|PornHD|Jasmin|livejasmin|imlive|brazzers|fapster|Chaturbate)(\.|\,) *com(\/.+)*)/gmi;
 class LinkFilter extends ModerationFilter{
    constructor(filterType,description,enabled, ban, timeoutLength) {
        super(filterType,description,enabled, ban, timeoutLength);
    }
 
-    checkIfMatch(message) {
-        if (discordLink.exec(message)) {
-            let reason = ` Auto detect [Link] Don't post discord invites in chat... | ${message}`
-            return [true, this.getActionType(), reason];
+    checkIfMatch(message, socialArray) {
+        let isDiscordLink = discordLink.exec(string)
+        if (isDiscordLink) {
+            if (!this.checkIfAllowedHandle(isDiscordLink,socialArray)) {
+                let reason = ` Auto detect [Link] Don't post discord invites in chat... | ${message}`
+                return [true, this.getActionType(), reason];
+            }
         } else if (nsfwLink.exec(message)) {
             let reason = ` Auto detect [Link] Don't link nsfw content in Twitch chat. | ${message}`
             return [true, this.getActionType(), reason];
         }
+    }
+
+    checkIfAllowedHandle(isDiscordLink, socialArray) {
+        let handleTag = isDiscordLink.groups['handle'];
+        let allowedHandle;
+        for (let objectKey in socialArray) {
+            let currentObj = socialArray[objectKey]
+            let keyName = Object.keys(currentObj)[0];
+            if(keyName == 'discord') {
+                let objValue = Object.values(currentObj)[0];
+                allowedHandle = objValue;
+                break;
+            }
+        }
+        if (allowedHandle === undefined) { // If there is no specified discord link saved in socials, return false.
+            return false;
+        }
+        return handleTag.toLowerCase() === allowedHandle.toLowerCase(); // true if the social handle in the message is the same as the allowed one.
     }
 }
 module.exports.LinkFilter = LinkFilter;

--- a/caibot/Channel/moderation/ModActions.js
+++ b/caibot/Channel/moderation/ModActions.js
@@ -14,7 +14,7 @@ async function startListen(channelSettings,chatClient) {
 
                 let currentTime = Utils.getDateHHMMSS();
                 let twitchUsername = msg.userInfo.displayName;
-                let actionDetails = await channelSettings.moderationSettings.checkFilters(message,user,msg);
+                let actionDetails = await channelSettings.moderationSettings.checkFilters(message,user,msg, channelSettings.socials);
             
                 if (actionDetails !== undefined) {
                     let takeAction = actionDetails[0];

--- a/caibot/Channel/moderation/Moderation.js
+++ b/caibot/Channel/moderation/Moderation.js
@@ -18,7 +18,7 @@ class Moderation {
         }
     };
 
-    async checkFilters(message,user,msg) {
+    async checkFilters(message,user,msg,socialArray) {
         if (this.filters.ascii.isEnabled()) {
             let ascii = await this.filters.ascii.checkIfAscii(message,msg);
             if (ascii !== undefined) {
@@ -50,7 +50,7 @@ class Moderation {
             }
         }
         if (this.filters.link.isEnabled()) {
-            let link = await this.filters.link.checkIfMatch(message)
+            let link = await this.filters.link.checkIfMatch(message,socialArray)
             if (link !== undefined) {
                 return link;
             }

--- a/caibot/ChannelConnection.js
+++ b/caibot/ChannelConnection.js
@@ -18,7 +18,7 @@ module.exports.connectToChannels = async function (channelChunkSize, joinInterva
     botChannels = JSON.parse(await fs.readFile(PATH_CHANNELS,'UTF-8'));
     currentlyRunningChannels = FileHandler.getOperatingChannels(botChannels.joined_channels); //saves all channels the bot is in
     botChannels.channel_count = currentlyRunningChannels.length;
-    setInterval(prepareUpdate, 10000, PATH_CHANNELS, botChannels, channelObjects); //auto save to disk every 3s
+    setInterval(prepareUpdate, 10000, PATH_CHANNELS, botChannels, channelObjects); //auto save to disk every 10s
 
 
     /**
@@ -49,7 +49,7 @@ module.exports.connectToChannels = async function (channelChunkSize, joinInterva
     /**
      * This function is used to easier comply with Twitch rate limits.
      * The bot can only join X amount of channels in Y amount of time.
-     * Therefore this function fills the functionality to limit the JOIN/s rate.
+     * Therefore this function fills the functionality to limit the JOIN/s rate (see comment in index.js).
      * For each iteration of the loop, we join the channels in array X in the two-dimensional array.
      * 
      * @param {Array} channelChunks needs to be a two-dimensional array. Eg. [["#channel1, "#channel2"], ["#channel3", "#channel4"]]
@@ -102,7 +102,8 @@ module.exports.connectToChannels = async function (channelChunkSize, joinInterva
     async function reCreateChannelObject(jsonStructure) {
         //console.log(jsonStructure);
         return new TwitchChannel.TwitchChannel(jsonStructure.channel_key, jsonStructure.channel_name,
-            jsonStructure.messages, jsonStructure.mods, jsonStructure.moderationSettings.enabled,jsonStructure.commands.enabled,jsonStructure.reactions.enabled);
+            jsonStructure.messages, jsonStructure.socials, jsonStructure.mods, jsonStructure.moderationSettings.enabled,
+            jsonStructure.commands.enabled, jsonStructure.reactions.enabled);
     }
 
     //Updates the list of moderators for all channels.
@@ -151,7 +152,7 @@ module.exports.connectToChannels = async function (channelChunkSize, joinInterva
             await joinQueue.dequeue();
             console.log(Utils.TimeHandler.getDateHHMMSS() + " | Getting Mod List for: ", channel_key);
             let mods = await chatClient.getMods(channel_key);
-            let newChannelObject = new TwitchChannel.TwitchChannel(channel_key,channel_key.split('#').join(''),0,mods,true,true,false)
+            let newChannelObject = new TwitchChannel.TwitchChannel(channel_key,channel_key.split('#').join(''),0, [{"twitter":"caisesiume"}],mods,true,true,false)
             botChannels.joined_channels.push(newChannelObject); //adds the newly joined channel to the saved json structure
             botChannels.channel_count++;
         }


### PR DESCRIPTION
Basic functionality for the bot to "whitelist" set social handles in chat.

**_Use cases:_**

**Example 1.**
As a regular chatter, I can post a discord invite to the channels belonging community server without getting a timeout. 

**Example 2.**
As a regular chatter, I post an invite to a random discord server and get timed out in chat.
